### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', jruby, truffleruby]
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', jruby, truffleruby]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,9 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-require 'simplecov'
-SimpleCov.start
+unless RUBY_ENGINE=='truffleruby'
+  require 'simplecov'
+  SimpleCov.start
+end
 
 require 'monotime'
 


### PR DESCRIPTION
To get truffleruby to run green I had to disable simplecov for that case - there appears to be an incompatibility.

With these changes everything runs green.